### PR TITLE
Remote webdriver support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -255,6 +255,8 @@ The following variables are supported and can be set to override defaults:
 * ``sms_path`` (the path to be used by ``smsmock`` to save sms. Defaults to ``current_dir/sms`` )
 * ``mail_path`` (the path to be used by ``mailmock`` to save mail. Defaults to ``current_dir/mail`` )
 * ``default_browser``
+* ``remote_webdriver`` (whether to use the remote webdriver. Defaults to ``False``)
+* ``browser_args`` (a dict of additional keyword arguments used when creating a browser)
 * ``base_url``
 
 You can run the tests simply by issuing
@@ -282,7 +284,7 @@ When *behaving* is installed, it creates two scripts to help you test mail and s
     * Given a browser
       [opens the default browser, i.e. Firefox]
     * Given ``brand`` as the default browser
-      [sets the default browser to be ``brand``, where brand can be Firefox, Chrome, Safari, PhantomJS, or Remote]
+      [sets the default browser to be ``brand``, this is the browser name when using the remote webdriver or Firefox, Chrome, Safari or PhantomJS]
     * Given browser "``name``"
       [opens the browser named ``name``]
     * When I reload

--- a/src/behaving/web/__init__.py
+++ b/src/behaving/web/__init__.py
@@ -6,6 +6,10 @@ from urllib2 import URLError
 def setup(context):
     if not hasattr(context, 'default_browser'):
         context.default_browser = ''
+    if not hasattr(context, 'browser_args'):
+        context.browser_args = {}
+    if not hasattr(context, 'remote_webdriver'):
+        context.remote_webdriver = False
     if not hasattr(context, 'attachment_dir'):
         context.attachment_dir = '/'
     if not hasattr(context, 'base_url'):

--- a/src/behaving/web/steps/browser.py
+++ b/src/behaving/web/steps/browser.py
@@ -10,10 +10,14 @@ def given_a_browser(context):
 @step(u'browser "{name}"')
 def named_browser(context, name):
     if name not in context.browsers:
-        if context.default_browser:
-            context.browsers[name] = Browser(context.default_browser)
-        else:
-            context.browsers[name] = Browser()
+        args = context.browser_args.copy()
+        if context.remote_webdriver:
+            args['driver_name'] = 'remote'
+            if context.default_browser:
+                args['browser'] = context.default_browser
+        elif context.default_browser:
+            args['driver_name'] = context.default_browser
+        context.browsers[name] = Browser(**args)
     context.browser = context.browsers[name]
     context.browser.switch_to_window(context.browser.windows[0])
 
@@ -21,7 +25,6 @@ def named_browser(context, name):
 @step(u'{brand} as the default browser')
 def given_some_browser(context, brand):
     brand = brand.lower()
-    assert brand in [u'firefox', u'chrome', u'phantomjs', 'remote'], u'Unknown browser'
     context.default_browser = brand
 
 


### PR DESCRIPTION
- `remote_webdriver` (whether to use the remote webdriver. Defaults to `False`)
- `browser_args` (a dict of additional keyword arguments used when creating a browser)

default_browser now sets the remote browser when using remote_webdriver.
