### PR TITLE
press an element in one call to avoid timeouts

### DIFF
--- a/src/behaving/web/steps/forms.py
+++ b/src/behaving/web/steps/forms.py
@@ -50,15 +50,13 @@ def i_select(context, value, name):
 @step(u'I press "{name}"')
 @persona_vars
 def i_press(context, name):
-    button = \
-        context.browser.find_by_id(name) or \
-        context.browser.find_by_name(name) or \
-        context.browser.find_by_xpath("//button[text()='%s']" % name) or \
-        context.browser.find_by_xpath("//button[contains(text(), '%s')]" % name) or \
-        context.browser.find_link_by_text(name) or \
-        context.browser.find_link_by_partial_text(name)
-    assert button, u'Element not found'
-    button.first.click()
+    element = context.browser.find_by_xpath(
+        ("//*[@id='%(name)s']|"
+         "//*[@name='%(name)s']|"
+         "//button[contains(text(), '%(name)s')]|"
+         "//a[contains(text(), '%(name)s')]") % {'name': name})
+    assert element, u'Element not found'
+    element.first.click()
 
 
 @step(u'I press the element with xpath "{xpath}"')


### PR DESCRIPTION
each browser.find\* suffers from the standard splinter timeout of 2 seconds
this introduces unnecessary delay if you don't match the first condition
e.g. if you change default timeout to 10s and element is not found
you will have to wait 1 minute for this step to execute

this change should do exactly the same while not incurring any additional timeouts
