### PR TITLE
Fix mail steps for multi-mode emails with both text and html

### DIFF
--- a/src/behaving/mail/steps.py
+++ b/src/behaving/mail/steps.py
@@ -5,8 +5,7 @@ from behaving.personas.persona import persona_vars
 
 
 MAIL_TIMEOUT = 5
-URL_RE = re.compile(r'((?:ftp|https?)://(localhost|([12]?[0-9]{1,2}.){3}([12]?[0-9]{1,2})|(?:[a-z0-9](?:[-a-z0-9]*[a-z0-9])?\.)+(?:com|edu|biz|org|gov|int|info|mil|net|name|museum|coop|aero|[a-z][a-z]))\b(?::\d+)?(?:\/[^"\'<>()\[\]{}\s\x7f-\xff]*(?:[.,?]+[^"\'<>()\[\]{}\s\x7f-\xff]+)*)?)', re.I|re.S|re.U)
-
+URL_RE = re.compile(r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', re.I|re.S|re.U)
 
 @step(u'I should receive an email at "{address}" containing "{text}"')
 @persona_vars
@@ -42,7 +41,7 @@ def click_link_in_email(context, address):
     mails = context.mail.user_messages(address)
     assert mails, u'message not found'
     mail = email.message_from_string(mails[0])
-    links = URL_RE.findall(mail.get_payload().replace('=\n', ''))
+    links = URL_RE.findall(str(mail).replace('=\n', ''))
     assert links, u'link not found'
-    url = links[0][0]
+    url = links[0]
     context.browser.visit(url)


### PR DESCRIPTION
text/html content. Change url regex to be simpler and more accepting of
alternate TLDs and other oddities (we use .local tld for development
and CI)

str(mail) will return the full body of the mail, whereas with multipart
emails get_payload() can return a list of sub-messages with seperate
payloads each
