### PR TITLE
Add browser retrying on exception

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 0.8 - Unreleased
 ----------------
 
+- Updated step "given browser '{name}'" to retry up to three times if the webdriver fails to initialize
+  [kageurufu]
+
 0.7 - 2014-04-07
 ----------------
 

--- a/README.rst
+++ b/README.rst
@@ -258,6 +258,7 @@ The following variables are supported and can be set to override defaults:
 * ``mail_path`` (the path to be used by ``mailmock`` to save mail. Defaults to ``current_dir/mail`` )
 * ``default_browser``
 * ``default_browser_size`` (tuple (width, height), applied to each browser as it's created)
+* ``max_browser_attempts`` (how many times to retry creating the browser if it fails)
 * ``remote_webdriver`` (whether to use the remote webdriver. Defaults to ``False``)
 * ``browser_args`` (a dict of additional keyword arguments used when creating a browser)
 * ``base_url``

--- a/src/behaving/web/__init__.py
+++ b/src/behaving/web/__init__.py
@@ -20,6 +20,8 @@ def setup(context):
         context.base_url = ''
     if not hasattr(context, 'default_browser_size'):
         context.default_browser_size = None
+    if not hasattr(context, 'max_browser_attempts'):
+        context.max_browser_attempts = 3
     if hasattr(context, 'screenshots_dir'):
         if not os.path.isdir(context.screenshots_dir):
             try:

--- a/src/behaving/web/steps/browser.py
+++ b/src/behaving/web/steps/browser.py
@@ -3,6 +3,7 @@ import time
 
 from behave import step
 from splinter.browser import Browser
+from selenium.common.exceptions import WebDriverException
 
 
 @step(u'a browser')
@@ -20,7 +21,15 @@ def named_browser(context, name):
                 args['browser'] = context.default_browser
         elif context.default_browser:
             args['driver_name'] = context.default_browser
-        context.browsers[name] = Browser(**args)
+        browser_attempts = 0
+        while browser_attempts < context.max_browser_attempts:
+            try:
+                context.browsers[name] = Browser(**args)
+                break
+            except WebDriverException as e:
+                browser_attempts += 1
+        else:
+            raise WebDriverException("Failed to initialize browser")
     context.browser = context.browsers[name]
     context.browser.switch_to_window(context.browser.windows[0])
     if context.default_browser_size:


### PR DESCRIPTION
On our test server, we were frequently getting Failed to connect to ghostdriver exceptions during test execution (~120 scenarios at the moment), causing builds and deploys to fail. This change allows for more stability by allowing the browser to be restarted if it fails the first time. Added configuration and changelog as well

context.max_browser_attempts defaults to 3 tries, but is adjustable.
