### PR TITLE
Splinter has updated to 0.7.0, and removed the switch_to_window function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0rc2-dev'
+version = '1.0rc3-dev'
 
 setup(name='behaving',
       version=version,
@@ -22,7 +22,7 @@ setup(name='behaving',
       namespace_packages=['behaving'],
       include_package_data=True,
       zip_safe=False,
-      install_requires=['setuptools', 'parse', 'behave', 'splinter', 'Appium-Python-Client'],
+      install_requires=['setuptools', 'parse', 'behave', 'splinter==0.6.0', 'Appium-Python-Client'],
       entry_points="""
       [console_scripts]
       mailmock = behaving.mail.mock:main


### PR DESCRIPTION
Until behaving has a proper upgrade to handle the new 0.7.0, require the last stable working version to resolve test failures
