### PR TITLE
Support for non ASCII/UTF subject in email + tests

### DIFF
--- a/src/behaving/mail/steps.py
+++ b/src/behaving/mail/steps.py
@@ -1,4 +1,5 @@
 import email
+from email.header import decode_header
 import re
 import quopri
 import parse
@@ -7,8 +8,8 @@ from behaving.personas.persona import persona_vars
 
 
 MAIL_TIMEOUT = 5
-URL_RE = re.compile(r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+',
-                    re.I | re.S | re.U)
+URL_RE = re.compile(r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|\
+                    (?:%[0-9a-fA-F][0-9a-fA-F]))+', re.I | re.S | re.U)
 
 
 @step(u'I should receive an email at "{address}" containing "{text}"')
@@ -24,9 +25,13 @@ def should_receive_email_containing_text(context, address, text):
 @step(u'I should receive an email at "{address}" with subject "{subject}"')
 @persona_vars
 def should_receive_email_with_subject(context, address, subject):
+    def get_subject_from_mail(mail):
+        text, encoding = decode_header(mail.get('Subject'))[0]
+        return text.decode(encoding) if encoding else text
+
     def filter_contents(mail):
         mail = email.message_from_string(mail)
-        return subject.encode('utf-8') == mail.get('Subject')
+        return subject == get_subject_from_mail(mail)
 
     assert context.mail.user_messages(address, filter_contents), u'message not found'
 
@@ -67,20 +72,30 @@ def click_link_in_email(context, address):
 @step(u'I parse the email I received at "{address}" and set "{expression}"')
 @persona_vars
 def parse_email_set_var(context, address, expression):
-    expression = expression.encode('utf-8')
     assert context.persona is not None, u'no persona is setup'
     msgs = context.mail.user_messages(address)
     assert msgs, u'no email received'
     mail = email.message_from_string(msgs[-1])
-    mail = quopri.decodestring(mail.get_payload()).decode('utf-8')
-    import pdb; pdb.set_trace()
+    mail = quopri.decodestring(mail.get_payload()).decode("utf-8")
     parser = parse.compile(expression)
     res = parser.parse(mail)
 
+    # Make an implicit assumption that there might be something before the expression
+    if res is None:
+        expr = '{}' + expression
+        parser = parse.compile(expr)
+        res = parser.parse(mail)
+
+    # Make an implicit assumption that there might be something after the expression
+    if res is None:
+        expr = expression + '{}'
+        parser = parse.compile(expr)
+        res = parser.parse(mail)
+
     # Make an implicit assumption that there might be something before/after the expression
     if res is None:
-        expression = '{}' + expression + '{}'
-        parser = parse.compile(expression)
+        expr = '{}' + expression + '{}'
+        parser = parse.compile(expr)
         res = parser.parse(mail)
 
     assert res, u'expression not found'

--- a/src/behaving/mail/steps.py
+++ b/src/behaving/mail/steps.py
@@ -2,7 +2,6 @@ import email
 from email.header import decode_header
 import re
 import quopri
-import parse
 from behave import step
 from behaving.personas.persona import persona_vars
 
@@ -76,27 +75,31 @@ def parse_email_set_var(context, address, expression):
     msgs = context.mail.user_messages(address)
     assert msgs, u'no email received'
     mail = email.message_from_string(msgs[-1])
-    mail = quopri.decodestring(mail.get_payload()).decode("utf-8")
+    text = quopri.decodestring(mail.get_payload()).decode("utf-8")
+    parse_text(context, text, expression)
+
+def parse_text(context, text, expression):
+    import parse
     parser = parse.compile(expression)
-    res = parser.parse(mail)
+    res = parser.parse(text)
 
     # Make an implicit assumption that there might be something before the expression
     if res is None:
         expr = '{}' + expression
         parser = parse.compile(expr)
-        res = parser.parse(mail)
+        res = parser.parse(text)
 
     # Make an implicit assumption that there might be something after the expression
     if res is None:
         expr = expression + '{}'
         parser = parse.compile(expr)
-        res = parser.parse(mail)
+        res = parser.parse(text)
 
     # Make an implicit assumption that there might be something before/after the expression
     if res is None:
         expr = '{}' + expression + '{}'
         parser = parse.compile(expr)
-        res = parser.parse(mail)
+        res = parser.parse(text)
 
     assert res, u'expression not found'
     assert res.named, u'expression not found'

--- a/src/behaving/sms/steps.py
+++ b/src/behaving/sms/steps.py
@@ -1,7 +1,6 @@
-import parse
 from behave import step
 from behaving.personas.persona import persona_vars
-
+from behaving.mail.steps import parse_text
 
 @step(u'I set "{key}" to the body of the sms I received at "{tel}"')
 @persona_vars
@@ -19,20 +18,8 @@ def parse_sms_set_var(context, tel, expression):
     msgs = context.sms.user_messages(tel)
     assert msgs, u'no sms received'
 
-    parser = parse.compile(expression)
-    res = parser.parse(msgs[-1])
-
-    # Make an implicit assumption that there might be something before/after the expression
-    if res is None:
-        expression = '{}' + expression + '{}'
-        parser = parse.compile(expression)
-        res = parser.parse(msgs[-1])
-
-    assert res, u'expression not found'
-    assert res.named, u'expression not found'
-    for key, val in res.named.items():
-        context.persona[key] = val
-
+    msg = msgs[-1]
+    parse_text(context, msg, expression)
 
 @step(u'I should receive an sms at "{tel}" containing "{text}"')
 @persona_vars

--- a/src/behaving/tests/features/browser.feature
+++ b/src/behaving/tests/features/browser.feature
@@ -100,7 +100,7 @@ Feature: Browser handling
             Given "Bar" as the persona
             When I visit "http://localhost:8080"
             Then I wait for 4 seconds
-            And I close browser "Bar"
+            And I close the browser "Bar"
 
         Then I wait for 4 seconds
-        And I close browser "Foo"
+        And I close the browser "Foo"

--- a/src/behaving/tests/features/forms.feature
+++ b/src/behaving/tests/features/forms.feature
@@ -13,7 +13,7 @@ Feature: Forms
         And I choose "male" from "sex"
         And I check "subscribe"
         And I uncheck "digest"
-        And I toggle "diggest"
+        And I toggle "digest"
         And I select "no" from "countries"
         And I select "gr" from "countries"
         And I attach the file "test.txt" to "file"

--- a/src/behaving/tests/features/mail.feature
+++ b/src/behaving/tests/features/mail.feature
@@ -9,17 +9,17 @@ Feature: Email steps
 
     @email
     Scenario: Send Receive email with non ANSII subject
-        When I send an email to "foo@bar.com" with encoded "iso8859_7" subject "Γειά σου και χαρά σου" and body "Χαιρετίσματα απο τη Σίφνο"
+        When I send an email to "foo@bar.com" with encoded "iso8859_7" subject "φοο βαρ" and body "βαρ φοο"
         Then I should receive an email at "foo@bar.com"
-        And I should receive an email at "foo@bar.com" with subject "Γειά σου και χαρά σου"
-        And I should receive an email at "foo@bar.com" containing "Χαιρετίσματα απο τη Σίφνο"
+        And I should receive an email at "foo@bar.com" with subject "φοο βαρ"
+        And I should receive an email at "foo@bar.com" containing "βαρ φοο"
 
-        When I send an email to "foo@bar.com" with encoded "iso8859_10" subject "Korleis har du det?/Korleis går det?" and body "Det er bedre å dø stående enn å leve på knærne."
+        When I send an email to "foo@bar.com" with encoded "iso8859_10" subject "få bår" and body "bår få"
         Then I should receive an email at "foo@bar.com"
-        And I should receive an email at "foo@bar.com" with subject "Korleis har du det?/Korleis går det?"
-        And I should receive an email at "foo@bar.com" containing "Det er bedre å dø stående enn å leve på knærne."
+        And I should receive an email at "foo@bar.com" with subject "få bår"
+        And I should receive an email at "foo@bar.com" containing "bår få"
 
-    @email @runme
+    @email
     Scenario: Receive email with attachment
         When I send an email to "foo@bar.com" with subject "Hello world" and body "Greetings from a BDD world!" and attachment "test.txt"
         Then I should receive an email at "foo@bar.com" with attachment "test.txt"
@@ -42,9 +42,9 @@ Feature: Email steps
     @email
     Scenario: International friendly
         Given "Foo" as the persona
-        When I send an email to "foo@bar.com" with subject "Καλημέρα" and body "Έλα ρε, τί γίνεται; Ο κωδικός είναι: 'hax0r'."
+        When I send an email to "foo@bar.com" with subject "få bår" and body "bår få: 'hax0r'."
         Then I should receive an email at "foo@bar.com"
-        And I should receive an email at "foo@bar.com" with subject "Καλημέρα"
-        And I should receive an email at "foo@bar.com" containing "Έλα ρε"
-        When I parse the email I received at "foo@bar.com" and set "κωδικός είναι: '{password}'"
+        And I should receive an email at "foo@bar.com" with subject "få bår"
+        And I should receive an email at "foo@bar.com" containing "bår få"
+        When I parse the email I received at "foo@bar.com" and set "få: '{password}'"
         Then "password" is set to "hax0r"

--- a/src/behaving/tests/features/mail.feature
+++ b/src/behaving/tests/features/mail.feature
@@ -8,6 +8,18 @@ Feature: Email steps
         And I should receive an email at "foo@bar.com" containing "BDD"
 
     @email
+    Scenario: Send Receive email with non ANSII subject
+        When I send an email to "foo@bar.com" with encoded "iso8859_7" subject "Γειά σου και χαρά σου" and body "Χαιρετίσματα απο τη Σίφνο"
+        Then I should receive an email at "foo@bar.com"
+        And I should receive an email at "foo@bar.com" with subject "Γειά σου και χαρά σου"
+        And I should receive an email at "foo@bar.com" containing "Χαιρετίσματα απο τη Σίφνο"
+
+        When I send an email to "foo@bar.com" with encoded "iso8859_10" subject "Korleis har du det?/Korleis går det?" and body "Det er bedre å dø stående enn å leve på knærne."
+        Then I should receive an email at "foo@bar.com"
+        And I should receive an email at "foo@bar.com" with subject "Korleis har du det?/Korleis går det?"
+        And I should receive an email at "foo@bar.com" containing "Det er bedre å dø stående enn å leve på knærne."
+
+    @email @runme
     Scenario: Receive email with attachment
         When I send an email to "foo@bar.com" with subject "Hello world" and body "Greetings from a BDD world!" and attachment "test.txt"
         Then I should receive an email at "foo@bar.com" with attachment "test.txt"

--- a/src/behaving/tests/features/steps/steps.py
+++ b/src/behaving/tests/features/steps/steps.py
@@ -1,4 +1,5 @@
 from email.mime.base import MIMEBase
+from email.header import Header
 import os.path
 
 try:
@@ -38,9 +39,9 @@ def send_sms(context, to, body):
 @when('I send an email to "{to}" with subject "{subject}" and body "{body}" and attachment "{filename}"')
 def send_email_attachment(context, to, subject, body, filename):
     msg = MIMEMultipart(From='test@localhost',
-                        To=to,
-                        Subject=subject.encode('utf-8'))
-    msg.attach(MIMEText(body.encode('utf-8')))
+                        To=to)
+    msg['Subject'] = Header(subject, 'utf-8')
+    msg.attach(MIMEText(body))
     path = os.path.join(context.attachment_dir, filename)
     with open(path, 'rb') as fil:
         attachment = MIMEBase('application', 'octet-stream')
@@ -50,14 +51,23 @@ def send_email_attachment(context, to, subject, body, filename):
 
     s = smtplib.SMTP('localhost', 8025)
     s.sendmail('test@localhost', [to], msg.as_string())
-    s.close()
+    s.quit()
 
 
 @when('I send an email to "{to}" with subject "{subject}" and body "{body}"')
 def send_email(context, to, subject, body):
-
     msg = MIMEText(body.encode('utf-8'))
-    msg['Subject'] = subject.encode('utf-8')
+    msg['Subject'] = Header(subject, 'utf-8')
+    msg['To'] = to
+    msg['From'] = 'test@localhost'
+    s = smtplib.SMTP('localhost', 8025)
+    s.sendmail('test@localhost', [to], msg.as_string())
+    s.quit()
+
+@when('I send an email to "{to}" with encoded "{encoding}" subject "{subject}" and body "{body}"')
+def send_email_with_non_ascii_subject(context, to, encoding, subject, body):
+    msg = MIMEText(body.encode('utf-8'))
+    msg['Subject'] = Header(subject.encode(encoding), encoding)
     msg['To'] = to
     msg['From'] = 'test@localhost'
     s = smtplib.SMTP('localhost', 8025)

--- a/src/behaving/web/steps/url.py
+++ b/src/behaving/web/steps/url.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     from urllib.parse import urljoin, urlparse
 from behave import step
-import parse
+from behaving.mail.steps import parse_text
 
 from behaving.personas.persona import persona_vars
 
@@ -45,9 +45,4 @@ def the_browser_url_should_not_contain(context, text):
 def parse_url_set_var(context, expression):
     assert context.persona is not None, u'no persona is setup'
     url = urlparse(context.browser.url).path
-    parser = parse.compile(expression)
-    res = parser.parse(url)
-    assert res, u'expression not found'
-    assert res.named, u'expression not found'
-    for key, val in res.named.items():
-        context.persona[key] = val
+    parse_text(context, url, expression)

--- a/src/behaving/web/steps/url.py
+++ b/src/behaving/web/steps/url.py
@@ -42,7 +42,7 @@ def the_browser_url_should_not_contain(context, text):
 
 @step(u'I parse the url path and set "{expression}"')
 @persona_vars
-def parse_sms_set_var(context, expression):
+def parse_url_set_var(context, expression):
     assert context.persona is not None, u'no persona is setup'
     url = urlparse(context.browser.url).path
     parser = parse.compile(expression)


### PR DESCRIPTION
1) Added support for any encoding in email subject.
2) Fixed failing tests
3) Altered parse_email_set_var to be more lenient while matching values
