### PR TITLE
Parse context.text for persona vars.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 1.4.2 - Unreleased
 ------------------
 
+- Make persona variables usable in steps that receive a body of text.
+  [MihaiBalint]
+
 - Alerts containing text steps, tests for alerts.
   [ggozad]
 

--- a/README.rst
+++ b/README.rst
@@ -106,8 +106,14 @@ Within a test and given a persona, you can now use ``$var_name`` to access a var
     And I set "title" to the text of "document-title"
     And I fill in "delete" with "$title"
     And I set "address.country" to the text of "country"
+    And I set "postaddress" to:
+    """
+    $fullname
+    $address.street, $address.zip, $address.country
+    """
 
 would fill in the field with id ``name`` with ``Gandalf the Grey``, ``street`` with ``Rivendell street 1`` set the variable ``title`` to the text of the element with id ``document-title`` and reuse the variable ``title`` to fill in the field with id ``delete``. It would also store the value of the field with id "country" in address[``country``].
+The ``$var_name`` pattern is also usable in the text received by steps that expect a body of text, which means that the ``postaddress`` persona variable will contain Gandalf's complete snail-mail postage address nicely formatted on multiple lines.
 
 Hello Persona example
 ---------------------
@@ -452,6 +458,11 @@ When *behaving* is installed, it creates three scripts to help you test mail, gc
 
 * Given "``name``" as the persona
 * When I set "``key``" to "``value``"
+* When I set "``key``" to:
+  """
+  ``some longer body of text``
+  ``usually multiline``
+  """
 * When I clone persona "``source``" to "``target``"
 * Then "``key``" is set to "``value``"
 

--- a/src/behaving/personas/persona.py
+++ b/src/behaving/personas/persona.py
@@ -21,29 +21,32 @@ class PersonaVarMatcher(object):
     def __init__(self, func, *args):
         self.func = func
 
-    def replace_one(self, context, target_value):
-        if isinstance(target_value, unicode):
-            target_value = target_value.encode('utf-8')
-        variables = var_exp.findall(str(target_value))
-        for var in variables:
+    def _get_variables(self, target):
+        if isinstance(target, unicode):
+            target = target.encode('utf-8')
+        return var_exp.findall(str(target))
+
+    def _replace_variables(self, context, target):
+        for var in self._get_variables(target):
             value = context.persona[var]
 
             if isinstance(value, basestring):
-                target_value = target_value.replace('$' + var, value)
+                target = target.replace('$' + var, value)
             else:
-                target_value = value
-        if isinstance(target_value, basestring):
-            target_value = target_value.replace('\$', '$')
+                target = value
+        if isinstance(target, basestring):
+            target = target.replace('\$', '$')
 
-        return target_value
+        return target
 
     def replace(self, *args, **kwargs):
         context = args[0]
         if hasattr(context, 'persona'):
             for kwname, kwvalue in kwargs.items():
-                kwargs[kwname] = self.replace_one(context, kwargs[kwname])
+                kwargs[kwname] = self._replace_variables(
+                    context, kwargs[kwname])
             if hasattr(context, 'text') and context.text:
-                context.text = self.replace_one(context, context.text)
+                context.text = self._replace_variables(context, context.text)
 
         self.func.__call__(*args, **kwargs)
 

--- a/src/behaving/personas/persona.py
+++ b/src/behaving/personas/persona.py
@@ -21,22 +21,29 @@ class PersonaVarMatcher(object):
     def __init__(self, func, *args):
         self.func = func
 
+    def replace_one(self, context, target_value):
+        if isinstance(target_value, unicode):
+            target_value = target_value.encode('utf-8')
+        variables = var_exp.findall(str(target_value))
+        for var in variables:
+            value = context.persona[var]
+
+            if isinstance(value, basestring):
+                target_value = target_value.replace('$' + var, value)
+            else:
+                target_value = value
+        if isinstance(target_value, basestring):
+            target_value = target_value.replace('\$', '$')
+
+        return target_value
+
     def replace(self, *args, **kwargs):
         context = args[0]
         if hasattr(context, 'persona'):
             for kwname, kwvalue in kwargs.items():
-                if isinstance(kwvalue, unicode):
-                    kwvalue = kwvalue.encode('utf-8')
-                variables = var_exp.findall(str(kwvalue))
-                for var in variables:
-                    value = context.persona[var]
-
-                    if isinstance(value, basestring):
-                        kwargs[kwname] = kwargs[kwname].replace('$' + var, value)
-                    else:
-                        kwargs[kwname] = value
-                if isinstance(kwargs[kwname], basestring):
-                    kwargs[kwname] = kwargs[kwname].replace('\$', '$')
+                kwargs[kwname] = self.replace_one(context, kwargs[kwname])
+            if hasattr(context, 'text') and context.text:
+                context.text = self.replace_one(context, context.text)
 
         self.func.__call__(*args, **kwargs)
 

--- a/src/behaving/personas/steps.py
+++ b/src/behaving/personas/steps.py
@@ -27,6 +27,13 @@ def set_variable(context, key, val):
     context.persona[key] = val
 
 
+@step(u'I set "{key}" to')
+@persona_vars
+def set_variable_text(context, key):
+    assert context.persona is not None, u'no persona is setup'
+    context.persona[key] = context.text
+
+
 @step(u'"{key}" is set to "{val}"')
 @persona_vars
 def key_is_val(context, key, val):

--- a/src/behaving/tests/features/personas.feature
+++ b/src/behaving/tests/features/personas.feature
@@ -18,6 +18,22 @@ Feature: Use Personas
         When I set "mydict.foo" to "aaa"
 
     @personas
+    Scenario: Set variables text
+        Given "Foo" as the persona
+        When I set "foo" to:
+        """
+        Hello world
+        """
+        And I set "bar" to "Hello world"
+        Then "foo" is set to "$bar"
+        When I set "foo" to "world"
+        And I set "bar" to:
+        """
+        Hello $foo
+        """
+        Then "bar" is set to "Hello world"
+
+    @personas
     Scenario: Escaped persona variables
         Given "Foo" as the persona
         When I set "foo" to "\$1.00"


### PR DESCRIPTION
In addition to replacing persona variables in step parameters this change replaces persona variables in context.text if it is available. 

For testing purposes I also added a step to assign context.text to a persona variable.