### PR TITLE
Ignore headers when finding links in emails

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,9 @@ Changelog
 - When I focus on "{name}".
   [ggozad]
 
+- Ignore headers when finding links in emails.
+  [kageurufu]
+
 1.5.4 - 2016-05-04
 ------------------
 

--- a/src/behaving/mail/steps.py
+++ b/src/behaving/mail/steps.py
@@ -68,7 +68,12 @@ def click_link_in_email(context, address):
     mails = context.mail.user_messages(address)
     assert mails, u'message not found'
     mail = email.message_from_string(mails[-1])
-    links = URL_RE.findall(str(mail).replace('=\n', ''))
+    links = []
+    payloads = mail.get_payload()
+    if isinstance(payloads, str):
+        payloads = [payloads]
+    for payload in payloads:
+        links.extend(URL_RE.findall(str(payload).replace('=\n', '')))
     assert links, u'link not found'
     url = links[0]
     context.browser.visit(url)


### PR DESCRIPTION
We are now sending multiple headers, including more detailed mailing list headers. These include several URLs, such as unsubscribe links. Our tests fail due to these links in the headers being included in the search for links.

This PR will only search message bodies for links, which I think would be the expected result