### PR TITLE
Fix quote handling for xpath

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,9 @@ Changelog
 - When I focus on "{name}".
   [ggozad]
 
+- Handle quotes in "I click the link with text that contains" step.
+  [kageurufu]
+
 1.5.4 - 2016-05-04
 ------------------
 

--- a/src/behaving/web/steps/links.py
+++ b/src/behaving/web/steps/links.py
@@ -23,7 +23,13 @@ def click_link_with_text(context, text):
 @step(u'I click the link with text that contains "{text}"')
 @persona_vars
 def click_link_with_text_that_contains(context, text):
-    anchors = context.browser.find_by_xpath("//a[contains(string(), '%s')]" % text)
+    text = text.replace('"', '\\"')  # Escape all double quotes
+    text = text.replace("'", """', "'", '""")  # Escape all single quotes
+    if "'" in text:
+        xpath = "//a[contains(string(), concat('%s'))]" % text
+    else:
+        xpath = "//a[contains(string(), '%s')]" % text
+    anchors = context.browser.find_by_xpath(xpath)
     assert anchors, 'Link not found'
     anchors[0].click()
 


### PR DESCRIPTION
xpath has no way of properly escaping quotes. 

The prior version would break horribly if you had quotes in your text, such as Jacob's

This will escape double quotes (as those are escapes are handled by javascript, and inside wrapping single quotes), and convert single quotes to string concatenations with double quoted single quotes inside. 

I did attempt to use both &quot;/&apos; as well as "" or '' to escape them, which just caused javascript errors across browsers. 

This solution has been testing against a variety of mixed quotes in the search string, and seems fairly robust