### PR TITLE
Useful ability set chrome_options via browser_args

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -308,6 +308,17 @@ You can run the tests simply by issuing
 
     ./bin/behave ./features
 
+For chrome and docker issues, the code below is useful
+
+::
+
+    from selenium.webdriver.chrome.options import Options
+    chrome_options = Options()
+    chrome_options.add_argument('--no-sandbox')
+    context.browser_args = {
+        'options': chrome_options
+    }
+
 Mail, GCM and SMS mock servers
 -------------------------
 

--- a/src/behaving/web/chrome.py
+++ b/src/behaving/web/chrome.py
@@ -13,9 +13,9 @@ class WebDriver(BaseWebDriver):
     driver_name = "Chrome"
 
     def __init__(self, user_agent=None, wait_time=2, fullscreen=False,
-                 **kwargs):
+                 options=None, **kwargs):
 
-        options = Options()
+        options = Options() if options is None else options
 
         if user_agent is not None:
             options.add_argument("--user-agent=" + user_agent)


### PR DESCRIPTION
Added the ability to pass options for chrome browser.
For example:
```
from selenium.webdriver.chrome.options import Options
chrome_options.add_argument('--no-sandbox')
context.browser_args = {
    'options': chrome_options
}
```