### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ ARG CHROME_DRIVER_VERSION=2.30
 
 ARG PHANTOMJS_VERSION=1.9.8
 
-ARG CORDOVA_VERSION=4.3.0
-
 # Following line fixes https://github.com/SeleniumHQ/docker-selenium/issues/87
 ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
 


### PR DESCRIPTION
Update installations methods for browsers and change base image to python:2

Known issues:

For more clear `Dockerfile`, need apply modifications for tests mentoined here: https://github.com/ggozad/behaving/pull/68

Option `--no-sandbox` is required for start chrome, i dont know how it apply for chrome browser via feature file:
```
@web
Scenario: Select Chrome browser
    Given Chrome as the default browser
    Given a browser
```

Also problem in final scenario:
```
  @web
  Scenario: Create Named Browser visit a site and close by name.  # tests/features/browser.feature:82
    Given Browser "aBrowser"                                      # src/behaving/web/steps/browser.py:20 3.161s
    When I visit "http://localhost:8080"                          # src/behaving/personas/persona.py:42 0.095s
    Then I wait for 4 seconds                                     # src/behaving/personas/persona.py:42 4.004s
    And I close the browser "aBrowser"                            # src/behaving/web/steps/browser.py:60 0.019s
    Given Browser "anotherBrowser"                                # src/behaving/web/steps/browser.py:20 3.127s
    When I visit "http://localhost:8080"                          # src/behaving/personas/persona.py:42 0.084s
    Then I wait for 4 seconds                                     # src/behaving/personas/persona.py:42 4.004s
    And I close the browser "anotherBrowser"                      # src/behaving/web/steps/browser.py:60 0.018s
Exception WebDriverException: Message: Tried to run command without establishing a connection

Traceback (most recent call last):
  File "./bin/behave", line 18, in <module>
    sys.exit(behave.__main__.main())
  File "/root/behaving/eggs/behave-1.2.5-py2.7.egg/behave/__main__.py", line 109, in main
    failed = runner.run()
  File "/root/behaving/eggs/behave-1.2.5-py2.7.egg/behave/runner.py", line 672, in run
    return self.run_with_paths()
  File "/root/behaving/eggs/behave-1.2.5-py2.7.egg/behave/runner.py", line 693, in run_with_paths
    return self.run_model()
  File "/root/behaving/eggs/behave-1.2.5-py2.7.egg/behave/runner.py", line 483, in run_model
    failed = feature.run(self)
  File "/root/behaving/eggs/behave-1.2.5-py2.7.egg/behave/model.py", line 523, in run
    failed = scenario.run(runner)
  File "/root/behaving/eggs/behave-1.2.5-py2.7.egg/behave/model.py", line 919, in run
    runner.run_hook('after_scenario', runner.context, self)
  File "/root/behaving/eggs/behave-1.2.5-py2.7.egg/behave/runner.py", line 405, in run_hook
    self.hooks[name](context, *args)
  File "tests/features/environment.py", line 32, in after_scenario
    benv.after_scenario(context, scenario)
  File "/root/behaving/src/behaving/environment.py", line 51, in after_scenario
    webenv.after_scenario(context, scenario)
  File "/root/behaving/src/behaving/web/environment.py", line 39, in after_scenario
    teardown(context)
  File "/root/behaving/src/behaving/web/__init__.py", line 52, in teardown
    browser.quit()
  File "/root/behaving/eggs/splinter-0.7.5-py2.7.egg/splinter/driver/webdriver/__init__.py", line 476, in quit
    self.driver.quit()
  File "/root/behaving/eggs/selenium-3.4.3-py2.7.egg/selenium/webdriver/firefox/webdriver.py", line 181, in quit
    RemoteWebDriver.quit(self)
  File "/root/behaving/eggs/selenium-3.4.3-py2.7.egg/selenium/webdriver/remote/webdriver.py", line 551, in quit
    self.execute(Command.QUIT)
  File "/root/behaving/eggs/selenium-3.4.3-py2.7.egg/selenium/webdriver/remote/webdriver.py", line 256, in execute
    self.error_handler.check_response(response)
  File "/root/behaving/eggs/selenium-3.4.3-py2.7.egg/selenium/webdriver/remote/errorhandler.py", line 194, in check_response
    raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.WebDriverException: Message: Tried to run command without establishing a connection
```

And on build stage command `python bootstrap.py` have deprecation warning:
```
ez_setup.py is deprecated and when using it setuptools will be pinned to 33.1.1 since it's the last version that supports setuptools self upgrade/installation, check https://github.com/pypa/setuptools/issues/581 for more info; use pip to install setuptools
```
