### PR TITLE
Use default wait time

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ defaults:
 - `default_browser`
 - `default_browser_size` (tuple (width, height), applied to each
   browser as it's created)
+- `wait_time` (int, set a default timeout for `I should/not see ...` steps)
 - `max_browser_attempts` (how many times to retry creating the browser
   if it fails)
 - `remote_webdriver_url` (points to your selenium hub url or remote

--- a/README.md
+++ b/README.md
@@ -356,7 +356,6 @@ defaults:
 - `default_browser`
 - `default_browser_size` (tuple (width, height), applied to each
   browser as it's created)
-- `wait_time` (int, set a default timeout for `I should/not see ...` steps)
 - `max_browser_attempts` (how many times to retry creating the browser
   if it fails)
 - `remote_webdriver_url` (points to your selenium hub url or remote

--- a/src/behaving/web/__init__.py
+++ b/src/behaving/web/__init__.py
@@ -1,10 +1,19 @@
 import os
 import tempfile
+from functools import wraps
 from urllib.error import URLError
 
-from behaving.web import electron
-from behaving.web import chrome
-from behaving.web import firefox
+from behaving.web import chrome, electron, firefox
+
+
+def set_timeout(func):
+    @wraps(func)
+    def wrapper(context, *args, **kwargs):
+        if "timeout" not in kwargs and getattr(context, "wait_time", None) is not None:
+            kwargs["timeout"] = context.wait_time
+        return func(context, *args, **kwargs)
+
+    return wrapper
 
 
 # Generic setup/teardown for compatibility with pytest et al.

--- a/src/behaving/web/steps/basic.py
+++ b/src/behaving/web/steps/basic.py
@@ -6,7 +6,9 @@ from behaving.personas.persona import persona_vars
 
 # Accepts a lambda as first paramter, returns lambda result on success, or False on timeout
 def _retry(func, timeout=0, delay=1):
-    assert isinstance(func, type(lambda: None)), "Retry expects a lambda as the first argument"
+    assert isinstance(
+        func, type(lambda: None)
+    ), "Retry expects a lambda as the first argument"
 
     start = time.time()
     while True:
@@ -33,28 +35,36 @@ def wait_for_timeout(context, timeout):
 @persona_vars
 def show_element_by_id(context, id):
     assert context.browser.find_by_id(id)
-    context.browser.execute_script('document.getElementById("%s").style.display="inline";' % id)
+    context.browser.execute_script(
+        'document.getElementById("%s").style.display="inline";' % id
+    )
 
 
 @step('I hide the element with id "{id}"')
 @persona_vars
 def hide_element_by_id(context, id):
     assert context.browser.find_by_id(id)
-    context.browser.execute_script('document.getElementById("%s").style.display="none";' % id)
+    context.browser.execute_script(
+        'document.getElementById("%s").style.display="none";' % id
+    )
 
 
 @step('I should see "{text}"')
 @step('I should see "{text}" within {timeout:d} seconds')
 @persona_vars
 def should_see_within_timeout(context, text, timeout=None):
-    assert context.browser.is_text_present(text, wait_time=timeout), f'Text "{text}" not found'
+    assert context.browser.is_text_present(
+        text, wait_time=timeout
+    ), f'Text "{text}" not found'
 
 
 @step('I should not see "{text}"')
 @step('I should not see "{text}" within {timeout:d} seconds')
 @persona_vars
 def should_not_see_within_timeout(context, text, timeout=None):
-    assert context.browser.is_text_not_present(text, wait_time=timeout), f'Text "{text}" was found'
+    assert context.browser.is_text_not_present(
+        text, wait_time=timeout
+    ), f'Text "{text}" was found'
 
 
 @step('I should see an element with id "{id}"')

--- a/src/behaving/web/steps/basic.py
+++ b/src/behaving/web/steps/basic.py
@@ -1,14 +1,12 @@
 import time
-from behave import step
 
+from behave import step
 from behaving.personas.persona import persona_vars
 
 
 # Accepts a lambda as first paramter, returns lambda result on success, or False on timeout
 def _retry(func, timeout=0, delay=1):
-    assert isinstance(
-        func, type(lambda: None)
-    ), "Retry expects a lambda as the first argument"
+    assert isinstance(func, type(lambda: None)), "Retry expects a lambda as the first argument"
 
     start = time.time()
     while True:
@@ -25,120 +23,82 @@ def _retry(func, timeout=0, delay=1):
             return None
 
 
-@step(u"I wait for {timeout:d} seconds")
+@step("I wait for {timeout:d} seconds")
 @persona_vars
 def wait_for_timeout(context, timeout):
     time.sleep(timeout)
 
 
-@step(u'I show the element with id "{id}"')
+@step('I show the element with id "{id}"')
 @persona_vars
 def show_element_by_id(context, id):
     assert context.browser.find_by_id(id)
-    context.browser.execute_script(
-        'document.getElementById("%s").style.display="inline";' % id
-    )
+    context.browser.execute_script('document.getElementById("%s").style.display="inline";' % id)
 
 
-@step(u'I hide the element with id "{id}"')
+@step('I hide the element with id "{id}"')
 @persona_vars
 def hide_element_by_id(context, id):
     assert context.browser.find_by_id(id)
-    context.browser.execute_script(
-        'document.getElementById("%s").style.display="none";' % id
-    )
+    context.browser.execute_script('document.getElementById("%s").style.display="none";' % id)
 
 
-@step(u'I should see "{text}"')
+@step('I should see "{text}"')
+@step('I should see "{text}" within {timeout:d} seconds')
 @persona_vars
-def should_see(context, text):
-    assert context.browser.is_text_present(text), u'Text "%s" not found' % text
+def should_see_within_timeout(context, text, timeout=None):
+    assert context.browser.is_text_present(text, wait_time=timeout), f'Text "{text}" not found'
 
 
-@step(u'I should not see "{text}"')
+@step('I should not see "{text}"')
+@step('I should not see "{text}" within {timeout:d} seconds')
 @persona_vars
-def should_not_see(context, text):
-    assert context.browser.is_text_not_present(text), u'Text "%s" was found' % text
+def should_not_see_within_timeout(context, text, timeout=None):
+    assert context.browser.is_text_not_present(text, wait_time=timeout), f'Text "{text}" was found'
 
 
-@step(u'I should see "{text}" within {timeout:d} seconds')
+@step('I should see an element with id "{id}"')
+@step('I should see an element with id "{id}" within {timeout:d} seconds')
 @persona_vars
-def should_see_within_timeout(context, text, timeout):
-    assert context.browser.is_text_present(text, wait_time=timeout), (
-        u'Text "%s" not found' % text
-    )
-
-
-@step(u'I should not see "{text}" within {timeout:d} seconds')
-@persona_vars
-def should_not_see_within_timeout(context, text, timeout):
-    assert context.browser.is_text_not_present(text, wait_time=timeout), (
-        u'Text "%s" was found' % text
-    )
-
-
-@step(u'I should see an element with id "{id}"')
-@persona_vars
-def should_see_element_with_id(context, id):
-    assert context.browser.is_element_present_by_id(id), u"Element not found"
-
-
-@step(u'I should not see an element with id "{id}"')
-@persona_vars
-def should_not_see_element_with_id(context, id):
-    assert context.browser.is_element_not_present_by_id(id), u"Element was found"
-
-
-@step(u'I should see an element with id "{id}" within {timeout:d} seconds')
-@persona_vars
-def should_see_element_with_id_within_timeout(context, id, timeout):
+def should_see_element_with_id_within_timeout(context, id, timeout=None):
     assert context.browser.is_element_present_by_id(
         id, wait_time=timeout
-    ), u"Element not found"
+    ), f'Element with id "{id}" not found'
 
 
-@step(u'I should not see an element with id "{id}" within {timeout:d} seconds')
+@step('I should not see an element with id "{id}"')
+@step('I should not see an element with id "{id}" within {timeout:d} seconds')
 @persona_vars
-def should_not_see_element_with_id_within_timeout(context, id, timeout):
+def should_not_see_element_with_id_within_timeout(context, id, timeout=None):
     assert context.browser.is_element_not_present_by_id(
         id, wait_time=timeout
-    ), u"Element was found"
+    ), f'Element with id "{id}" was found'
 
 
-@step(u'I should see an element with xpath "{xpath}"')
+@step('I should see an element with xpath "{xpath}"')
+@step('I should see an element with xpath "{xpath}" within {timeout:d} seconds')
 @persona_vars
-def should_see_element_with_xpath(context, xpath):
-    assert context.browser.is_element_present_by_xpath(xpath), u"Element not found"
-
-
-@step(u'I should not see an element with xpath "{xpath}"')
-@persona_vars
-def should_not_see_element_with_xpath(context, xpath):
-    assert context.browser.is_element_not_present_by_xpath(xpath), u"Element was found"
-
-
-@step(u'I should see an element with xpath "{xpath}" within {timeout:d} seconds')
-@persona_vars
-def should_see_element_with_xpath_within_timeout(context, xpath, timeout):
+def should_see_element_with_xpath_within_timeout(context, xpath, timeout=None):
     assert context.browser.is_element_present_by_xpath(
         xpath, wait_time=timeout
-    ), u"Element not found"
+    ), f'Element with xpath "{xpath}" not found'
 
 
-@step(u'I should not see an element with xpath "{xpath}" within {timeout:d} seconds')
+@step('I should not see an element with xpath "{xpath}"')
+@step('I should not see an element with xpath "{xpath}" within {timeout:d} seconds')
 @persona_vars
-def should_not_see_element_with_xpath_within_timeout(context, xpath, timeout):
+def should_not_see_element_with_xpath_within_timeout(context, xpath, timeout=None):
     assert context.browser.is_element_not_present_by_xpath(
         xpath, wait_time=timeout
-    ), u"Element was found"
+    ), f'Element with xpath "{xpath}" was found'
 
 
-@step(u'I execute the script "{script}"')
+@step('I execute the script "{script}"')
 def execute_script(context, script):
     context.browser.execute_script(script)
 
 
-@step(u'I evaluate the script "{script}" and assign the result to "{key}"')
+@step('I evaluate the script "{script}" and assign the result to "{key}"')
 def evaluate_script(context, script, key):
-    assert context.persona is not None, u"no persona is setup"
+    assert context.persona is not None, "no persona is setup"
     context.persona[key] = context.browser.evaluate_script(script)

--- a/src/behaving/web/steps/css.py
+++ b/src/behaving/web/steps/css.py
@@ -7,7 +7,9 @@ from .basic import _retry
 
 
 @step('the element with xpath "{xpath}" should have the class "{cls}"')
-@step('the element with xpath "{xpath}" should have the class "{cls}" within {timeout:d} seconds')
+@step(
+    'the element with xpath "{xpath}" should have the class "{cls}" within {timeout:d} seconds'
+)
 @set_timeout
 def element_by_xpath_should_have_class_within_timeout(
     context, xpath: str, cls: str, timeout: int = 0
@@ -35,7 +37,9 @@ def element_by_xpath_should_not_have_class_within_timeout(
 
 @step('"{name}" should have the class "{cls}"')
 @step('"{name}" should have the class "{cls}" within {timeout:d} seconds')
-def element_should_have_class_within_timeout(context, name: str, cls: str, timeout: int = 0):
+def element_should_have_class_within_timeout(
+    context, name: str, cls: str, timeout: int = 0
+):
     element = context.browser.find_by_xpath(
         ("//*[@id='%(name)s']|" "//*[@name='%(name)s']") % {"name": name}
     )
@@ -47,7 +51,9 @@ def element_should_have_class_within_timeout(context, name: str, cls: str, timeo
 
 @step('"{name}" should not have the class "{cls}"')
 @step('"{name}" should not have the class "{cls}" within {timeout:d} seconds')
-def element_should_not_have_class_within_timeout(context, name: str, cls: str, timeout: int = 0):
+def element_should_not_have_class_within_timeout(
+    context, name: str, cls: str, timeout: int = 0
+):
     element = context.browser.find_by_xpath(
         ("//*[@id='%(name)s']|" "//*[@name='%(name)s']") % {"name": name}
     )
@@ -58,13 +64,21 @@ def element_should_not_have_class_within_timeout(context, name: str, cls: str, t
 
 
 @step('I should see an element with the css selector "{css}"')
-@step('I should see an element with the css selector "{css}" within {timeout:d} seconds')
-def should_see_element_with_css_within_timeout(context, css: str, timeout: Optional[int] = None):
-    assert context.browser.is_element_present_by_css(css, wait_time=timeout), "Element not found"
+@step(
+    'I should see an element with the css selector "{css}" within {timeout:d} seconds'
+)
+def should_see_element_with_css_within_timeout(
+    context, css: str, timeout: Optional[int] = None
+):
+    assert context.browser.is_element_present_by_css(
+        css, wait_time=timeout
+    ), "Element not found"
 
 
 @step('I should not see an element with the css selector "{css}"')
-@step('I should not see an element with the css selector "{css}" within {timeout:d} seconds')
+@step(
+    'I should not see an element with the css selector "{css}" within {timeout:d} seconds'
+)
 def should_not_see_element_with_css_within_timeout(
     context, css: str, timeout: Optional[int] = None
 ):
@@ -113,30 +127,46 @@ def _element_should_not_be_visible(context, css: str, timeout: int):
 
 def _n_elements_should_be_visible(context, expected: str, css: str, timeout: int):
     check = lambda: len(find_visible_by_css(context, css)) == expected
-    assert _retry(check, timeout), "Didn't find exactly {:d} visible elements".format(expected)
+    assert _retry(check, timeout), "Didn't find exactly {:d} visible elements".format(
+        expected
+    )
 
 
-def _at_least_n_elements_should_be_visible(context, expected: str, css: str, timeout: int):
+def _at_least_n_elements_should_be_visible(
+    context, expected: str, css: str, timeout: int
+):
     check = lambda: len(find_visible_by_css(context, css)) >= expected
-    assert _retry(check, timeout), "Didn't find at least {:d} visible elements".format(expected)
+    assert _retry(check, timeout), "Didn't find at least {:d} visible elements".format(
+        expected
+    )
 
 
 @step('the element with the css selector "{css}" should be visible')
-@step('the element with the css selector "{css}" should be visible within {timeout:d} seconds')
+@step(
+    'the element with the css selector "{css}" should be visible within {timeout:d} seconds'
+)
 @set_timeout
-def should_see_element_visible_with_css_within_timeout(context, css: str, timeout: int = 0):
+def should_see_element_visible_with_css_within_timeout(
+    context, css: str, timeout: int = 0
+):
     _element_should_be_visible(context, css, timeout)
 
 
 @step('the element with the css selector "{css}" should not be visible')
-@step('the element with the css selector "{css}" should not be visible within {timeout:d} seconds')
+@step(
+    'the element with the css selector "{css}" should not be visible within {timeout:d} seconds'
+)
 @set_timeout
-def should_not_see_element_visible_with_css_within_timeout(context, css: str, timeout: int = 0):
+def should_not_see_element_visible_with_css_within_timeout(
+    context, css: str, timeout: int = 0
+):
     _element_should_not_be_visible(context, css, timeout)
 
 
 @step('{n:d} elements with the css selector "{css}" should be visible')
-@step('{n:d} elements with the css selector "{css}" should be visible within {timeout:d} seconds')
+@step(
+    '{n:d} elements with the css selector "{css}" should be visible within {timeout:d} seconds'
+)
 @set_timeout
 def should_see_n_elements_visible_with_css_within_timeout(
     context, n: int, css: str, timeout: int = 0

--- a/src/behaving/web/steps/css.py
+++ b/src/behaving/web/steps/css.py
@@ -1,18 +1,17 @@
+from typing import Optional
+
 from behave import step
+from behaving.web import set_timeout
+
 from .basic import _retry
 
 
 @step('the element with xpath "{xpath}" should have the class "{cls}"')
-def element_with_xpath_should_have_class(context, xpath, cls):
-    element = context.browser.find_by_xpath(xpath)
-    assert element, "Element not found"
-    assert element.first.has_class(cls), "Class is not present on element"
-
-
-@step(
-    'the element with xpath "{xpath}" should have the class "{cls}" within {timeout:d} seconds'
-)
-def element_by_xpath_should_have_class_within_timeout(context, xpath, cls, timeout):
+@step('the element with xpath "{xpath}" should have the class "{cls}" within {timeout:d} seconds')
+@set_timeout
+def element_by_xpath_should_have_class_within_timeout(
+    context, xpath: str, cls: str, timeout: int = 0
+):
     element = context.browser.find_by_xpath(xpath)
     assert element, "Element not found"
     element = element.first
@@ -21,16 +20,12 @@ def element_by_xpath_should_have_class_within_timeout(context, xpath, cls, timeo
 
 
 @step('the element with xpath "{xpath}" should not have the class "{cls}"')
-def element_with_xpath_should_not_have_class(context, xpath, cls):
-    element = context.browser.find_by_xpath(xpath)
-    assert element, "Element not found"
-    assert not element.first.has_class(cls), "Class is present on element"
-
-
 @step(
     'the element with xpath "{xpath}" should not have the class "{cls}" within {timeout:d} seconds'
 )
-def element_by_xpath_should_not_have_class_within_timeout(context, xpath, cls, timeout):
+def element_by_xpath_should_not_have_class_within_timeout(
+    context, xpath: str, cls: str, timeout: int = 0
+):
     element = context.browser.find_by_xpath(xpath)
     assert element, "Element not found"
     element = element.first
@@ -39,16 +34,8 @@ def element_by_xpath_should_not_have_class_within_timeout(context, xpath, cls, t
 
 
 @step('"{name}" should have the class "{cls}"')
-def element_should_have_class(context, name, cls):
-    element = context.browser.find_by_xpath(
-        ("//*[@id='%(name)s']|" "//*[@name='%(name)s']") % {"name": name}
-    )
-    assert element, "Element not found"
-    assert element.first.has_class(cls), "Class is not present on element"
-
-
 @step('"{name}" should have the class "{cls}" within {timeout:d} seconds')
-def element_should_have_class_within_timeout(context, name, cls, timeout):
+def element_should_have_class_within_timeout(context, name: str, cls: str, timeout: int = 0):
     element = context.browser.find_by_xpath(
         ("//*[@id='%(name)s']|" "//*[@name='%(name)s']") % {"name": name}
     )
@@ -59,16 +46,8 @@ def element_should_have_class_within_timeout(context, name, cls, timeout):
 
 
 @step('"{name}" should not have the class "{cls}"')
-def element_should_not_have_class(context, name, cls):
-    element = context.browser.find_by_xpath(
-        ("//*[@id='%(name)s']|" "//*[@name='%(name)s']") % {"name": name}
-    )
-    assert element, "Element not found"
-    assert not element.first.has_class(cls), "Class is present on element"
-
-
 @step('"{name}" should not have the class "{cls}" within {timeout:d} seconds')
-def element_should_not_have_class_within_timeout(context, name, cls, timeout):
+def element_should_not_have_class_within_timeout(context, name: str, cls: str, timeout: int = 0):
     element = context.browser.find_by_xpath(
         ("//*[@id='%(name)s']|" "//*[@name='%(name)s']") % {"name": name}
     )
@@ -79,45 +58,27 @@ def element_should_not_have_class_within_timeout(context, name, cls, timeout):
 
 
 @step('I should see an element with the css selector "{css}"')
-def should_see_element_with_css(context, css):
-    assert context.browser.is_element_present_by_css(css), "Element not found"
+@step('I should see an element with the css selector "{css}" within {timeout:d} seconds')
+def should_see_element_with_css_within_timeout(context, css: str, timeout: Optional[int] = None):
+    assert context.browser.is_element_present_by_css(css, wait_time=timeout), "Element not found"
 
 
 @step('I should not see an element with the css selector "{css}"')
-def should_not_see_element_with_css(context, css):
-    assert context.browser.is_element_not_present_by_css(css), "Element was found"
-
-
-@step(
-    'I should see an element with the css selector "{css}" within {timeout:d} seconds'
-)
-def should_see_element_with_css_within_timeout(context, css, timeout):
-    assert context.browser.is_element_present_by_css(
-        css, wait_time=timeout
-    ), "Element not found"
-
-
-@step(
-    'I should not see an element with the css selector "{css}" within {timeout:d} seconds'
-)
-def should_not_see_element_with_css_within_timeout(context, css, timeout):
+@step('I should not see an element with the css selector "{css}" within {timeout:d} seconds')
+def should_not_see_element_with_css_within_timeout(
+    context, css: str, timeout: Optional[int] = None
+):
     assert context.browser.is_element_not_present_by_css(
         css, wait_time=timeout
     ), "Element was found"
 
 
 @step('I should see {n:d} elements with the css selector "{css}"')
-def should_see_n_elements_with_css(context, n, css):
-    element_list = context.browser.find_by_css(css)
-    list_length = len(element_list)
-    assert list_length == n, u"Found {0} elements, expected {1}".format(list_length, n)
-
-
 @step(
     'I should see at least {n:d} elements with the css selector "{css}" within {timeout:d} seconds'
 )
 def should_see_at_least_n_elements_with_css_within_timeout_seconds(
-    context, n, css, timeout
+    context, n: int, css: str, timeout: int = 0
 ):
     def _check():
         element_list = context.browser.find_by_css(css)
@@ -135,78 +96,60 @@ def should_see_at_least_n_elements_with_css_within_timeout_seconds(
 ###
 
 
-def find_visible_by_css(context, css):
+def find_visible_by_css(context, css: str):
     """Finds visible elements using a CSS selector."""
     return [elem for elem in context.browser.find_by_css(css) if elem.visible]
 
 
-def _element_should_be_visible(context, css, timeout):
+def _element_should_be_visible(context, css: str, timeout: int):
     check = lambda: len(find_visible_by_css(context, css)) > 0
     assert _retry(check, timeout), "Element not visible"
 
 
-def _element_should_not_be_visible(context, css, timeout):
+def _element_should_not_be_visible(context, css: str, timeout: int):
     check = lambda: len(find_visible_by_css(context, css)) == 0
     assert _retry(check, timeout), "Unexpectedly found visible element(s)"
 
 
-def _n_elements_should_be_visible(context, expected, css, timeout):
+def _n_elements_should_be_visible(context, expected: str, css: str, timeout: int):
     check = lambda: len(find_visible_by_css(context, css)) == expected
-    assert _retry(check, timeout), "Didn't find exactly {:d} visible elements".format(
-        expected
-    )
+    assert _retry(check, timeout), "Didn't find exactly {:d} visible elements".format(expected)
 
 
-def _at_least_n_elements_should_be_visible(context, expected, css, timeout):
+def _at_least_n_elements_should_be_visible(context, expected: str, css: str, timeout: int):
     check = lambda: len(find_visible_by_css(context, css)) >= expected
-    assert _retry(check, timeout), "Didn't find at least {:d} visible elements".format(
-        expected
-    )
+    assert _retry(check, timeout), "Didn't find at least {:d} visible elements".format(expected)
 
 
 @step('the element with the css selector "{css}" should be visible')
-def should_see_element_visible_with_css(context, css):
-    _element_should_be_visible(context, css, context.browser.wait_time)
-
-
-@step(
-    'the element with the css selector "{css}" should be visible within {timeout:d} seconds'
-)
-def should_see_element_visible_with_css_within_timeout(context, css, timeout):
+@step('the element with the css selector "{css}" should be visible within {timeout:d} seconds')
+@set_timeout
+def should_see_element_visible_with_css_within_timeout(context, css: str, timeout: int = 0):
     _element_should_be_visible(context, css, timeout)
 
 
 @step('the element with the css selector "{css}" should not be visible')
-def should_not_see_element_visible_with_css(context, css):
-    _element_should_not_be_visible(context, css, context.browser.wait_time)
-
-
-@step(
-    'the element with the css selector "{css}" should not be visible within {timeout:d} seconds'
-)
-def should_not_see_element_visible_with_css_within_timeout(context, css, timeout):
+@step('the element with the css selector "{css}" should not be visible within {timeout:d} seconds')
+@set_timeout
+def should_not_see_element_visible_with_css_within_timeout(context, css: str, timeout: int = 0):
     _element_should_not_be_visible(context, css, timeout)
 
 
 @step('{n:d} elements with the css selector "{css}" should be visible')
-def should_see_n_elements_visible_with_css(context, n, css):
-    _n_elements_should_be_visible(context, n, css, context.browser.wait_time)
-
-
-@step(
-    '{n:d} elements with the css selector "{css}" should be visible within {timeout:d} seconds'
-)
-def should_see_n_elements_visible_with_css_within_timeout(context, n, css, timeout):
+@step('{n:d} elements with the css selector "{css}" should be visible within {timeout:d} seconds')
+@set_timeout
+def should_see_n_elements_visible_with_css_within_timeout(
+    context, n: int, css: str, timeout: int = 0
+):
     _n_elements_should_be_visible(context, n, css, timeout)
 
 
 @step('at least {n:d} elements with the css selector "{css}" should be visible')
-def should_see_gte_n_elements_visible_with_css(context, n, css):
-    _at_least_n_elements_should_be_visible(context, n, css, context.browser.wait_time)
-
-
 @step(
     'at least {n:d} elements with the css selector "{css}" should be visible within {timeout:d} seconds'
 )
-def should_see_gte_n_elements_visible_with_css_within_timeout(context, n, css, timeout):
+@set_timeout
+def should_see_gte_n_elements_visible_with_css_within_timeout(
+    context, n: int, css: str, timeout: int = 0
+):
     _at_least_n_elements_should_be_visible(context, n, css, timeout)

--- a/src/behaving/web/steps/tables.py
+++ b/src/behaving/web/steps/tables.py
@@ -1,5 +1,4 @@
 from behave import then
-
 from behaving.personas.persona import persona_vars
 from splinter.exceptions import ElementDoesNotExist
 
@@ -9,7 +8,7 @@ def _process_table(table):
     headers = [el.text for el in table.find_by_tag("th")]
     # We should be using here rows = table.find_by_xpath("//tr[not(th)]")
     # but for some reason this duplicates the rows.
-    rows = [r for r in table.find_by_tag("tr") if r.find_by_tag("td")]
+    rows = [r for r in table.find_by_tag("tr") if r.find_by_tag("td", wait_time=0)]
     cells = [[cell.text for cell in row.find_by_tag("td")] for row in rows]
     return headers, cells
 


### PR DESCRIPTION
To reduce flakiness in CI, we're setting a default `browser.wait_time` to ~30-60s. Ran into a few issues as a result.

- Most of the `find_*` automatically use `browser.wait_time` if set, but the css checks use a special `_retry` func that currently does not.
    - added `@set_timeout` decorator for use in `behaving.web.steps.css` (or anywhere else)
    - consolidated `I should / should not ...` calls in `behaving.web.steps.basic`
- `behaving.web.steps.tables._process_table` function takes 2x the value of `browser.wait_time` for each call. Not noticeable when the low/default value of 2 is used, very noticeable when it is raised to the 30/60s
    - Set to use `wait_time=0` when checking for `td` elements, using the assumption that the table has finished loading if it is being parsed.

Tests pass locally with the exception of `downloads.feature` and `mouse.feature`. These are also not passing locally when run on the master branch though, so not sure what best to do for that.